### PR TITLE
Allow to use merging and interpolation functions without time dimension in input data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ nbsphinx = { version = "*", optional = true }
 nbmake = { version = ">=1.4.6", optional = true}
 ipython = { version = "*", optional = true }
 pykrige = ">=1.7.2"
-poligrain = ">=0.1.0"
+poligrain = { git = "https://github.com/OpenSenseAction/poligrain.git" }
 scipy = ">=1.14.0"
 numpy = ">=2.0.1"
 pandas = ">=2.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ nbsphinx = { version = "*", optional = true }
 nbmake = { version = ">=1.4.6", optional = true}
 ipython = { version = "*", optional = true }
 pykrige = ">=1.7.2"
-poligrain = { git = "https://github.com/OpenSenseAction/poligrain.git" }
+poligrain = ">=0.3.0"
 scipy = ">=1.14.0"
 numpy = ">=2.0.1"
 pandas = ">=2.2.2"

--- a/src/mergeplg/base.py
+++ b/src/mergeplg/base.py
@@ -420,6 +420,8 @@ class Base:
             assert da_cml.time.size == 1, "Select only one time step"
             assert da_gauge.time.size == 1, "Select only one time step"
 
+            if "time" not in da_grid.dims:
+                da_grid = da_grid.copy().expand_dims("time")
             # Calculate grid along CMLs using intersect weights
             grid_cml = (
                 plg.spatial.get_grid_time_series_at_intersections(

--- a/src/mergeplg/base.py
+++ b/src/mergeplg/base.py
@@ -453,6 +453,8 @@ class Base:
             assert da_grid.time.size == 1, "Select only one time step"
             assert da_cml.time.size == 1, "Select only one time step"
 
+            if "time" not in da_grid.dims:
+                da_grid = da_grid.copy().expand_dims("time")
             # Estimate grid at cml
             grid_at_obs = (
                 plg.spatial.get_grid_time_series_at_intersections(

--- a/src/mergeplg/interpolate.py
+++ b/src/mergeplg/interpolate.py
@@ -47,6 +47,8 @@ class InterpolateIDW(Base):
         Interpolate observations for one time step. The function assumes that
         the x0 are updated using the update class method.
 
+        Input data can have a time dimension of length 1 or no time dimension.
+
         Parameters
         ----------
         da_grid: xarray.DataArray
@@ -83,14 +85,6 @@ class InterpolateIDW(Base):
         if "time" not in da_grid.dims:
             da_grid = da_grid.copy().expand_dims("time")
             time_dim_was_expanded = True
-        if da_cml is not None and np.any(da_grid.time != da_cml.time):
-            msg = "`da_grid` and `da_cml` DataArray need to have matching time stamps."
-            raise ValueError(msg)
-        if da_gauge is not None and np.any(da_grid.time != da_gauge.time):
-            msg = (
-                "`da_grid` and `da_gauge` DataArray need to have matching time stamps."
-            )
-            raise ValueError(msg)
 
         # Update x0 geometry for CML and gauge
         self.update(da_cml=da_cml, da_gauge=da_gauge)

--- a/src/mergeplg/interpolate.py
+++ b/src/mergeplg/interpolate.py
@@ -180,6 +180,8 @@ class InterpolateOrdinaryKriging(Base):
         Interpolates ground observations for one time step. The function assumes
         that the x0 are updated using the update class method.
 
+        Input data can have a time dimension of length 1 or no time dimension.
+
         Parameters
         ----------
         da_grid: xarray.DataArray

--- a/src/mergeplg/interpolate.py
+++ b/src/mergeplg/interpolate.py
@@ -51,7 +51,7 @@ class InterpolateIDW(Base):
         ----------
         da_grid: xarray.DataArray
             Dataframe providing the grid for interpolation. Must contain
-            projected xs and ys coordinates.
+            projected x_grid and y_grid coordinates.
         da_cml: xarray.DataArray
             CML observations. Must contain the projected midpoint
             coordinates (x, y).
@@ -190,7 +190,7 @@ class InterpolateOrdinaryKriging(Base):
         ----------
         da_grid: xarray.DataArray
             Dataframe providing the grid for interpolation. Must contain
-            projected xs and ys coordinates.
+            projected x_grid and y_grid coordinates.
         da_cml: xarray.DataArray
             CML observations. Must contain the projected midpoint
             coordinates (x, y).

--- a/src/mergeplg/merge.py
+++ b/src/mergeplg/merge.py
@@ -402,7 +402,7 @@ class MergeKrigingExternalDrift(Base):
         )
 
         # Remove radar time dimension
-        rad_field = da_rad.isel(time=0).data
+        rad_field = da_rad.isel(time=0).data if "time" in da_rad.dims else da_rad.data
 
         # Set zero values to nan, these are ignored in ked function
         rad_field[rad_field <= 0] = np.nan
@@ -422,4 +422,12 @@ class MergeKrigingExternalDrift(Base):
         # Remove negative values
         adjusted[(adjusted < 0) | np.isnan(adjusted)] = 0
 
-        return xr.DataArray(data=[adjusted], coords=da_rad.coords, dims=da_rad.dims)
+        if "time" in da_rad.dims:
+            da_adjusted = xr.DataArray(
+                data=[adjusted], coords=da_rad.coords, dims=da_rad.dims
+            )
+        else:
+            da_adjusted = xr.DataArray(
+                data=adjusted, coords=da_rad.coords, dims=da_rad.dims
+            )
+        return da_adjusted

--- a/src/mergeplg/merge.py
+++ b/src/mergeplg/merge.py
@@ -293,13 +293,13 @@ class MergeDifferenceOrdinaryKriging(Base):
 
         # Adjust radar field
         if method == "additive":
-            adjusted = interpolated + da_rad.isel(time=0).data
-            adjusted[adjusted < 0] = 0
+            adjusted = interpolated + da_rad
+            adjusted.data[adjusted < 0] = 0
         elif method == "multiplicative":
-            adjusted = interpolated * da_rad.isel(time=0).data
-            adjusted[adjusted < 0] = 0
+            adjusted = interpolated * da_rad
+            adjusted.data[adjusted < 0] = 0
 
-        return xr.DataArray(data=[adjusted], coords=da_rad.coords, dims=da_rad.dims)
+        return adjusted
 
 
 class MergeKrigingExternalDrift(Base):

--- a/src/mergeplg/merge.py
+++ b/src/mergeplg/merge.py
@@ -136,13 +136,13 @@ class MergeDifferenceIDW(Base):
 
         # Adjust radar field
         if method == "additive":
-            adjusted = interpolated + da_rad.isel(time=0).data
-            adjusted[adjusted < 0] = 0
+            adjusted = interpolated + da_rad
+            adjusted.data[adjusted < 0] = 0
         elif method == "multiplicative":
-            adjusted = interpolated * da_rad.isel(time=0).data
-            adjusted[adjusted < 0] = 0
+            adjusted = interpolated * da_rad
+            adjusted.data[adjusted < 0] = 0
 
-        return xr.DataArray(data=[adjusted], coords=da_rad.coords, dims=da_rad.dims)
+        return adjusted
 
 
 class MergeDifferenceOrdinaryKriging(Base):

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -123,3 +123,19 @@ def test_idw_interpolate_with_data_without_time_dim():
     np.testing.assert_almost_equal(
         R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
     )
+    # Same with gauge data ds_geauges instead of ds_cmls
+    R_grid_idw_no_time_dim = idw_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+        p=3,
+        idw_method="standard",
+    )
+    R_grid_idw_with_time_dim = idw_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+        p=3,
+        idw_method="standard",
+    ).isel(time=0)
+    np.testing.assert_almost_equal(
+        R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
+    )

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -102,3 +102,24 @@ def test_blockkriging_vs_pykrige():
     interp_field_pykrige = [z.reshape(da_grid.x_grid.shape)]
 
     np.testing.assert_almost_equal(interp_field_pykrige, interp_field)
+
+
+def test_interpolate_with_data_without_time_dim():
+    idw_interpolator = interpolate.InterpolateIDW(min_observations=2)
+    # Make sure that the interpolation works with and without time dimension
+    # in the supplied data arrays and that resulta are the same
+    R_grid_idw_no_time_dim = idw_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+        p=3,
+        idw_method="standard",
+    )
+    R_grid_idw_with_time_dim = idw_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+        p=3,
+        idw_method="standard",
+    ).isel(time=0)
+    np.testing.assert_almost_equal(
+        R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
+    )

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -139,3 +139,32 @@ def test_idw_interpolate_with_data_without_time_dim():
     np.testing.assert_almost_equal(
         R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
     )
+
+
+def test_ok_interpolate_with_data_without_time_dim():
+    ok_interpolator = interpolate.InterpolateOrdinaryKriging(min_observations=2)
+    # Make sure that the interpolation works with and without time dimension
+    # in the supplied data arrays and that resulta are the same
+    R_grid_idw_no_time_dim = ok_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+    )
+    R_grid_idw_with_time_dim = ok_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+    ).isel(time=0)
+    np.testing.assert_almost_equal(
+        R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
+    )
+    # Same with gauge data ds_geauges instead of ds_cmls
+    R_grid_idw_no_time_dim = ok_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+    )
+    R_grid_idw_with_time_dim = ok_interpolator.interpolate(
+        da_grid=ds_rad.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+    ).isel(time=0)
+    np.testing.assert_almost_equal(
+        R_grid_idw_no_time_dim.data, R_grid_idw_with_time_dim.data
+    )

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -104,7 +104,7 @@ def test_blockkriging_vs_pykrige():
     np.testing.assert_almost_equal(interp_field_pykrige, interp_field)
 
 
-def test_interpolate_with_data_without_time_dim():
+def test_idw_interpolate_with_data_without_time_dim():
     idw_interpolator = interpolate.InterpolateIDW(min_observations=2)
     # Make sure that the interpolation works with and without time dimension
     # in the supplied data arrays and that resulta are the same

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -142,6 +142,7 @@ def test_MergeDifferenceIDW():
 
 def test_MergeDifferenceIDW_witout_time_dim_input_data():
     merge_IDW = merge.MergeDifferenceIDW(min_observations=2)
+    # test with gauge and CML data as input
     adjusted_with_time_dim = merge_IDW.adjust(
         da_rad=ds_rad.R.isel(time=[0]),
         da_cml=ds_cmls.R.isel(time=[0]),
@@ -152,6 +153,21 @@ def test_MergeDifferenceIDW_witout_time_dim_input_data():
         da_rad=ds_rad.R.isel(time=0),
         da_cml=ds_cmls.R.isel(time=0),
         da_gauge=ds_gauges.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+    # test with only CML data as input (we have to test that because
+    # ,at the time of writing, the relevant code is different)
+    adjusted_with_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
         method="additive",
     )
     np.testing.assert_almost_equal(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -378,6 +378,57 @@ def test_MergeDifferenceOrdinaryKriging():
         )
 
 
+def test_MergeDifferenceOrdinaryKriging_witout_time_dim_input_data():
+    merge_OK = merge.MergeDifferenceOrdinaryKriging(min_observations=2)
+    # test with gauge and CML data as input
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+    # test with only CML data as input (we have to test that because
+    # ,at the time of writing, the relevant code is different)
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+    # test with only gauge data as input (at the time of writing, this
+    # did not fail and was already covered by the behavior by `get_grid_at_points`
+    # which uses `poligrain.spatial.GridAtPoints`)
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+
+
 def test_MergeBlockKrigingExternalDrift():
     # CML and rain gauge overlapping sets
     da_cml_t1 = ds_cmls.isel(cml_id=[2, 1], time=[0]).R

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -144,13 +144,13 @@ def test_MergeDifferenceIDW_witout_time_dim_input_data():
     merge_IDW = merge.MergeDifferenceIDW(min_observations=2)
     adjusted_with_time_dim = merge_IDW.adjust(
         da_rad=ds_rad.R.isel(time=[0]),
-        # da_cml=ds_cmls.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
         da_gauge=ds_gauges.R.isel(time=[0]),
         method="additive",
     ).isel(time=0)
     adjusted_without_time_dim = merge_IDW.adjust(
         da_rad=ds_rad.R.isel(time=0),
-        # da_cml=ds_cmls.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
         da_gauge=ds_gauges.R.isel(time=0),
         method="additive",
     )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -173,6 +173,22 @@ def test_MergeDifferenceIDW_witout_time_dim_input_data():
     np.testing.assert_almost_equal(
         adjusted_with_time_dim.data, adjusted_without_time_dim.data
     )
+    # test with only gauge data as input (at the time of writing, this
+    # did not fail and was already covered by the behavior by `get_grid_at_points`
+    # which uses `poligrain.spatial.GridAtPoints`)
+    adjusted_with_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
 
 
 def test_MergeDifferenceOrdinaryKriging():

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -659,3 +659,48 @@ def test_MergeBlockKrigingExternalDrift():
         da_cml_t2.data.ravel(),
         decimal=0,  # not very precise, but decent
     )
+
+
+def test_MergeDifferenceKED_witout_time_dim_input_data():
+    merge_OK = merge.MergeKrigingExternalDrift(min_observations=2)
+    # test with gauge and CML data as input
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+    # test with only CML data as input (we have to test that because
+    # ,at the time of writing, the relevant code is different)
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_cml=ds_cmls.R.isel(time=[0]),
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_cml=ds_cmls.R.isel(time=0),
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+    # test with only gauge data as input (at the time of writing, this
+    # did not fail and was already covered by the behavior by `get_grid_at_points`
+    # which uses `poligrain.spatial.GridAtPoints`)
+    adjusted_with_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_OK.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -140,6 +140,25 @@ def test_MergeDifferenceIDW():
         assert gauge_r == merge_r
 
 
+def test_MergeDifferenceIDW_witout_time_dim_input_data():
+    merge_IDW = merge.MergeDifferenceIDW(min_observations=2)
+    adjusted_with_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=[0]),
+        # da_cml=ds_cmls.R.isel(time=[0]),
+        da_gauge=ds_gauges.R.isel(time=[0]),
+        method="additive",
+    ).isel(time=0)
+    adjusted_without_time_dim = merge_IDW.adjust(
+        da_rad=ds_rad.R.isel(time=0),
+        # da_cml=ds_cmls.R.isel(time=0),
+        da_gauge=ds_gauges.R.isel(time=0),
+        method="additive",
+    )
+    np.testing.assert_almost_equal(
+        adjusted_with_time_dim.data, adjusted_without_time_dim.data
+    )
+
+
 def test_MergeDifferenceOrdinaryKriging():
     # CML and rain gauge overlapping sets
     da_cml_t1 = ds_cmls.isel(cml_id=[2, 1], time=[0]).R


### PR DESCRIPTION
- closes #39 

TODO in this PR
- [x] fix for IDW interpolation
- [x] fix for OK interpolation
- [x] fix for IDW merging
- [x] fix for OK merging 
- [x] fix KED merging
- [x] depend on `poligrain` v0.3.0 (instead of current `main` from github in WIP code now)