### PR TITLE
remove drop_vars('time') at end of interpolator classes

### DIFF
--- a/src/mergeplg/interpolate.py
+++ b/src/mergeplg/interpolate.py
@@ -128,7 +128,6 @@ class InterpolateIDW(Base):
         )
         if time_dim_was_expanded:
             da_interpolated = da_interpolated.isel(time=0)
-            da_interpolated = da_interpolated.drop_vars("time")
         return da_interpolated
 
 
@@ -277,5 +276,4 @@ class InterpolateOrdinaryKriging(Base):
         )
         if time_dim_was_expanded:
             da_interpolated = da_interpolated.isel(time=0)
-            da_interpolated = da_interpolated.drop_vars("time")
         return da_interpolated


### PR DESCRIPTION
copy-paste first commit message:

------------

remove drop_vars('time') which I added to fix some problem in one of last PRs.
But I do not recall why exactly. It causese issue when passing data that has no time dimension and also no variable or coord named `time`, which happens with my synthetic example data. Maybe I found the problem when working in GridAtPoints and GridAtLines in poligrain and then just added the same code here without needing it. That means, thouhg, that the same problem might appear in GridAtLines and GridAtPoints. But let's wait and see if this really pops up as problem in poligrian...

------------

- related to #41 where the code with `drop_vars` was introduced.
- related to https://github.com/OpenSenseAction/poligrain/pull/96 where similar code was introduced in `poligrain` (which was maybe not a good idea) as a fix to https://github.com/OpenSenseAction/poligrain/pull/94/files
 