### PR TITLE
Faster and more memory efficient code for initalizing kriging functions

### DIFF
--- a/src/mergeplg/bk_functions.py
+++ b/src/mergeplg/bk_functions.py
@@ -162,7 +162,7 @@ class OBKrigTree:
             delta_y = x0[i, 0, :] - y_reshaped
             delta_x = x0[i, 1, :] - x_reshaped
             lengths = np.sqrt(delta_x**2 + delta_y**2)
-            var_line_point[:, i] = variogram(lengths).mean(axis = 1)
+            var_line_point[:, i] = variogram(lengths).mean(axis=1)
 
         # Store data to self
         self.mat = mat
@@ -547,34 +547,20 @@ def block_points_to_lengths(x0):
         can be calculated by lengths_point_l.mean(axis = (2, 3)).
 
     """
-    # Calculate the x distance between all points
-    delta_x = np.array(
-        [
-            x0[i][1] - x0[j][1].reshape(-1, 1)
-            for i in range(x0.shape[0])
-            for j in range(x0.shape[0])
-        ]
+    # Extract x and y coordinates
+    y_coords = x0[:, 0, :]
+    x_coords = x0[:, 1, :]
+
+    # Use broadcasting to calculate pairwise differences
+    delta_x = (
+        x_coords[np.newaxis, :, np.newaxis, :] - x_coords[:, np.newaxis, :, np.newaxis]
+    )
+    delta_y = (
+        y_coords[np.newaxis, :, np.newaxis, :] - y_coords[:, np.newaxis, :, np.newaxis]
     )
 
-    # Calculate the y-distance between all points
-    delta_y = np.array(
-        [
-            x0[i][0] - x0[j][0].reshape(-1, 1)
-            for i in range(x0.shape[0])
-            for j in range(x0.shape[0])
-        ]
-    )
-
-    # Calculate corresponding length between all points
-    lengths_point_l = np.sqrt(delta_x**2 + delta_y**2)
-
-    # Reshape to (n_lines, n_lines, disc, disc)
-    return lengths_point_l.reshape(
-        int(np.sqrt(lengths_point_l.shape[0])),
-        int(np.sqrt(lengths_point_l.shape[0])),
-        lengths_point_l.shape[1],
-        lengths_point_l.shape[2],
-    )
+    # Compute lengths between all pairs
+    return np.sqrt(delta_x**2 + delta_y**2)
 
 
 def construct_variogram(

--- a/tests/test_bk_functions.py
+++ b/tests/test_bk_functions.py
@@ -81,6 +81,7 @@ def test_block_points_to_lengths():
             ds_cmls.isel(cml_id=[0, 1]), discretization=2
         ).data
     )
+
     l0l0 = line[0, 0]  # Lengths from link0 to link0
     l0l1 = line[0, 1]  # Lengths from link0 to link0
     l1l0 = line[1, 0]  # Lengths from link0 to link0
@@ -98,14 +99,14 @@ def test_block_points_to_lengths():
         )
     ).all()
 
-    # Length matrix from line1 to lin2
+    # Length matrix from line1 to line2
     assert (
         l0l1
         == np.array(
             [
+                [1, np.sqrt(2**2 + 1), np.sqrt(3**2 + 2**2)],
                 [1, 1, np.sqrt(2**2 + 1)],
                 [np.sqrt(2**2 + 1), 1, 1],
-                [np.sqrt(3**2 + 2**2), np.sqrt(2**2 + 1), 1],
             ]
         )
     ).all()
@@ -115,9 +116,9 @@ def test_block_points_to_lengths():
         l1l0
         == np.array(
             [
-                [1, np.sqrt(2**2 + 1), np.sqrt(3**2 + 2**2)],
-                [1, 1, np.sqrt(2**2 + 1)],
-                [np.sqrt(1 + 2**2), 1, 1],
+                [1, 1, np.sqrt(2**2 + 1**2)],
+                [np.sqrt(2**2 + 1), 1, 1],
+                [np.sqrt(3**2 + 2**2), np.sqrt(2**2 + 1), 1],
             ]
         )
     ).all()


### PR DESCRIPTION
The PR solves #54 numpy broadcasting used too much memory when estimating distance between all observations and all grid points. The fix is to compute distance between a observation and all grid cells for each observation iteratively (thus not all data is loaded at the same time). The difference in execution time is the same. 

The PR also adds code for faster estimate of the distance between all points along all lines using broadcasting. 